### PR TITLE
app: Enforce UTC

### DIFF
--- a/app/schemas.py
+++ b/app/schemas.py
@@ -14,7 +14,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from datetime import datetime, timezone
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, validator
 from pydantic.dataclasses import dataclass
 from typing import Optional
 from fastapi import Query
@@ -31,6 +31,13 @@ class Measurement(BaseModel):
     latitude: float
     recorded: datetime = Field(
         default_factory=lambda: datetime.now(timezone.utc))
+
+    @validator('recorded')
+    def must_be_utc(cls, v):
+        v = v if v.tzinfo else v.replace(tzinfo=timezone.utc)
+        v = datetime.utcfromtimestamp(v.timestamp())
+        v = v.replace(tzinfo=timezone.utc)
+        return v
 
     class Config:
         orm_mode = True

--- a/tests/service.py
+++ b/tests/service.py
@@ -16,8 +16,8 @@
 import os
 import sys
 import asyncio
+import copy
 
-from datetime import datetime
 from urllib.parse import urlencode
 from alembic import config
 from fastapi.testclient import TestClient
@@ -38,7 +38,7 @@ measurements = [
         'pm10': 0.0,
         'longitude': -25.194156,
         'latitude': -57.521369,
-        'recorded': datetime.utcnow().isoformat(),
+        'recorded': '2020-10-24T20:47:57.370721+00:00',
     },
 ]
 
@@ -108,3 +108,27 @@ def test_distance_query():
     response = client.get(f'/api/v1/measurements?{urlencode(query)}')
     assert response.status_code == 200
     assert response.json() == measurements
+
+
+def test_enforce_utc():
+    original = measurements[0]
+
+    future = copy.deepcopy(original)
+    future['recorded'] = '2020-10-24T21:47:57.370721+01:00'
+
+    present = copy.deepcopy(original)
+    present['recorded'] = '2020-10-24T20:47:57.370721'
+
+    past = copy.deepcopy(original)
+    past['recorded'] = '2020-10-24T19:47:57.370721-01:00'
+
+    from app.schemas import Measurement
+
+    original = Measurement(**original)
+    future = Measurement(**future)
+    present = Measurement(**present)
+    past = Measurement(**past)
+
+    assert original == future
+    assert original == present
+    assert original == past


### PR DESCRIPTION
SQLite doesn't have TZ support, therefore, we must ensure that the date _always_ get converted to UTC before we store them.