### PR TITLE
Fixed a missing backslash in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ ENV     CONTAINER_PORT=5000 \
         TIMEOUT=300 \
         WORKER_CONNECTIONS=10 \
         WORKERS=3 \
-        DATABASE_URL=sqlite:///./default.db
+        DATABASE_URL=sqlite:///./default.db \
         LINKA_MASTER_KEY=""
 
 EXPOSE ${CONTAINER_PORT}


### PR DESCRIPTION
There was a missing BACKSLASH in Dockerfile that escaped my previous code review. Sorry. Fixing it now.