### PR TITLE
reports: Don't break on null stats

### DIFF
--- a/app/reports.py
+++ b/app/reports.py
@@ -79,7 +79,7 @@ class AQI:
     @staticmethod
     async def generate(db, query):
         sources = await Measurement.stats(db, query)
-        return [AQI.get_quality(s) for s in sources]
+        return [AQI.get_quality(s) for s in sources if s.pm2dot5_average is not None]
 
 
 class Stats:


### PR DESCRIPTION
Not all the sensors provide PM2.5, and therefore,
we can't generate calculate AQI for those. Don't
include those on the AQI report.